### PR TITLE
api refactor: outpoint interface add query latest block hash field

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -620,6 +620,10 @@ impl Index {
     self.begin_read()?.block_hash(height)
   }
 
+  pub(crate) fn latest_block(&self) -> Result<Option<(Height, BlockHash)>> {
+    self.begin_read()?.latest_block()
+  }
+
   pub(crate) fn blocks(&self, take: usize) -> Result<Vec<(u64, BlockHash)>> {
     let rtx = self.begin_read()?;
 

--- a/src/index/rtx.rs
+++ b/src/index/rtx.rs
@@ -48,4 +48,16 @@ impl Rtx<'_> {
       ),
     }
   }
+
+  pub(crate) fn latest_block(&self) -> Result<Option<(Height, BlockHash)>> {
+    Ok(
+      self
+        .0
+        .open_table(HEIGHT_TO_BLOCK_HASH)?
+        .range(0..)?
+        .next_back()
+        .and_then(|result| result.ok())
+        .map(|(height, hash)| (Height(height.value()), BlockHash::load(*hash.value()))),
+    )
+  }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -265,6 +265,7 @@ impl Server {
           ord::OrdInscription,
           ord::InscriptionDigest,
           ord::OutPointData,
+          ord::OutPointResult,
           ord::InscriptionAction,
           ord::TxInscription,
           ord::TxInscriptions,
@@ -274,7 +275,7 @@ impl Server {
           response::OrdOrdInscription,
           response::OrdTxInscriptions,
           response::OrdBlockInscriptions,
-          response::OrdOutPointData,
+          response::OrdOutPointResult,
 
 
           // Node Info schemas

--- a/src/subcommand/server/response.rs
+++ b/src/subcommand/server/response.rs
@@ -26,6 +26,7 @@ use {
 
   OrdOrdInscription = ApiResponse<ord::OrdInscription>,
   OrdOutPointData = ApiResponse<ord::OutPointData>,
+  OrdOutPointResult = ApiResponse<ord::OutPointResult>,
   OrdTxInscriptions = ApiResponse<ord::TxInscriptions>,
   OrdBlockInscriptions = ApiResponse<ord::BlockInscriptions>,
 


### PR DESCRIPTION
We should add the `blockhash` and `blockheight` in the data structure returned by the outpoint interface, so that users can clearly understand the indexer block status at the time of the request.